### PR TITLE
fix: flake, xorg, NVIDIA GeForce RTX 4060

### DIFF
--- a/crates/simulation/src/main.rs
+++ b/crates/simulation/src/main.rs
@@ -439,7 +439,6 @@ async fn create_window_surface<'w>(gpu: &Gpu, window: winit::window::Window) -> 
     let texture_format = surface_texture_format();
 
     let surface_caps = surface.get_capabilities(&gpu.adapter);
-    assert!(surface_caps.formats.contains(&texture_format));
 
     // Configure surface
     let PhysicalSize { width, height } = window.inner_size();
@@ -449,7 +448,7 @@ async fn create_window_surface<'w>(gpu: &Gpu, window: winit::window::Window) -> 
         width,
         height,
         present_mode: wgpu::PresentMode::Fifo,
-        alpha_mode: wgpu::CompositeAlphaMode::PreMultiplied,
+        alpha_mode: wgpu::CompositeAlphaMode::Opaque,
         view_formats: vec![],
         desired_maximum_frame_latency: 2,
     };
@@ -747,7 +746,7 @@ fn create_pipelines(device: &wgpu::Device, surface_format: wgpu::TextureFormat, 
 }
 
 fn surface_texture_format() -> wgpu::TextureFormat {
-    wgpu::TextureFormat::Rgba8UnormSrgb
+    wgpu::TextureFormat::Bgra8UnormSrgb
 }
 
 struct WindowSurface<'w> {


### PR DESCRIPTION
Hey, thanks for making this.

I saw this at the rust-cph meetup, and wanted to try running it at home.
Unfortunately, this didn't seem to work with xorg, and also the transparency
and color types didn't seem to be supported on my system.

I'm not sure I changed them to better values, but it made it possible to run on
my machine. I did see some issue where someone claimed `Bgra8UnormSrgb` was
supported on all platforms, but I'm not sure that's the case for `Opacity`.

I also changed the flake, so now `nix develop` should work without referencing
files outside of the repository.

I wonder if this works on your system, and with wayland.

Signed-off-by: Christina Sørensen <christina@cafkafk.com>
